### PR TITLE
reinitialize the cluster nodes when timeout happens

### DIFF
--- a/rediscluster/nodemanager.py
+++ b/rediscluster/nodemanager.py
@@ -225,7 +225,8 @@ class NodeManager(object):
                 r = self.get_redis_link(host=node["host"], port=node["port"], decode_responses=True)
                 cluster_slots = r.execute_command("cluster", "slots")
                 startup_nodes_reachable = True
-            except (ConnectionError, TimeoutError):
+            except (ConnectionError, TimeoutError) as e:
+                log.exception("Failed to sending 'cluster slots' to redis server: {0}".format(node), exc_info=e)
                 continue
             except ResponseError as e:
                 log.exception("ReseponseError sending 'cluster slots' to redis server")


### PR DESCRIPTION
I was trying to copy-paste the code from `redis-py` to this forked version, but the changes are huge that requires more efforts. So I decided to just trying to fix it on top of this forked version.

In most cases, we have `socket_timeout` set to `1` sec, while failover is happening, we often get the `TimeoutError`, at this point, the current code is trying to get a random node from the pool, however we might still get the node that is being failed over. So we are going to re-initialize the cluster nodes pool when there are timeout happening.

